### PR TITLE
Feature/allow force landing

### DIFF
--- a/src/__phutil_library_map__.php
+++ b/src/__phutil_library_map__.php
@@ -550,6 +550,7 @@ phutil_register_library_map(array(
     'ArcanistUselessOverridingMethodXHPASTLinterRule' => 'lint/linter/xhpast/rules/ArcanistUselessOverridingMethodXHPASTLinterRule.php',
     'ArcanistUselessOverridingMethodXHPASTLinterRuleTestCase' => 'lint/linter/xhpast/rules/__tests__/ArcanistUselessOverridingMethodXHPASTLinterRuleTestCase.php',
     'ArcanistUserAbortException' => 'exception/usage/ArcanistUserAbortException.php',
+    'ArcanistRevisionStatusException' => 'exception/usage/ArcanistRevisionStatusException.php',
     'ArcanistUserConfigurationSource' => 'config/source/ArcanistUserConfigurationSource.php',
     'ArcanistUserRef' => 'ref/user/ArcanistUserRef.php',
     'ArcanistUserSymbolHardpointQuery' => 'ref/user/ArcanistUserSymbolHardpointQuery.php',

--- a/src/exception/usage/ArcanistRevisionStatusException.php
+++ b/src/exception/usage/ArcanistRevisionStatusException.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Thrown when revision state is blocking next steps.
+ */
+final class ArcanistRevisionStatusException extends ArcanistUsageException {
+
+  public function __construct() {
+    parent::__construct(pht('Rejected: You should never land revision without review. If you know what you are doing and still want to land, use `FORCE_LAND=__reasson__` in revisions summary.'));
+  }
+
+}

--- a/src/runtime/ArcanistRuntime.php
+++ b/src/runtime/ArcanistRuntime.php
@@ -43,6 +43,8 @@ final class ArcanistRuntime {
       $log->writeError(pht('---'), $ex->getMessage());
     } catch (ArcanistConduitAuthenticationException $ex) {
       $log->writeError($ex->getTitle(), $ex->getBody());
+    } catch (ArcanistRevisionStatusException $ex) {
+      $log->writeError(pht('---'), $ex->getMessage());
     }
 
     return 1;


### PR DESCRIPTION
Related: 
- https://github.com/repo-mono/phlq/pull/86
- https://github.com/repo-mono/phlq/issues/85


Instruction:
Forced land can be done only when the string `FORCE_LAND=`__summary is present in diff summary.
you can edit summary with `arc diff --edit`

Test cases:
|`FORCE_LAND=` present | Is accepted | Result | 
|--------------------------| ----------- | ------- |
| ❌ | ❌ | exception raised|
| ❌ | ✅ | User can land changes |
|✅ | ❌ | User can land changes |
| ✅ | ✅ | User can land changes |
