### PR TITLE
Pass docs link to exception

### DIFF
--- a/src/config/arc/ArcanistArcConfigurationEngineExtension.php
+++ b/src/config/arc/ArcanistArcConfigurationEngineExtension.php
@@ -158,6 +158,11 @@ final class ArcanistArcConfigurationEngineExtension
           pht(
             'Specifies the default behavior when "arc land" is run with '.
             'no "--strategy" flag.')),
+      id(new ArcanistStringConfigOption())
+        ->setKey('land.notaccepted.readmore')
+        ->setSummary(
+          pht(
+            'Information why policy on revision acceptance changes.'))
     );
   }
 

--- a/src/config/arc/ArcanistArcConfigurationEngineExtension.php
+++ b/src/config/arc/ArcanistArcConfigurationEngineExtension.php
@@ -159,10 +159,15 @@ final class ArcanistArcConfigurationEngineExtension
             'Specifies the default behavior when "arc land" is run with '.
             'no "--strategy" flag.')),
       id(new ArcanistStringConfigOption())
-        ->setKey('land.notaccepted.readmore')
+        ->setKey('arc.land.notaccepted.message')
+        ->setDefaultValue(
+          pht(
+            'Rejected: You should never land revision without review. '.
+            'If you know what you are doing and still want to land, use `FORCE_LAND=__reason__` '.
+            'in revisions summary.'))
         ->setSummary(
           pht(
-            'Information why the policy of accepting reviews has changed.'))
+            'Error message when attempting to land a non-accepted revision.'))
     );
   }
 

--- a/src/config/arc/ArcanistArcConfigurationEngineExtension.php
+++ b/src/config/arc/ArcanistArcConfigurationEngineExtension.php
@@ -162,7 +162,7 @@ final class ArcanistArcConfigurationEngineExtension
         ->setKey('land.notaccepted.readmore')
         ->setSummary(
           pht(
-            'Information why policy on revision acceptance changes.'))
+            'Information why the policy of accepting reviews has changed.'))
     );
   }
 

--- a/src/exception/usage/ArcanistRevisionStatusException.php
+++ b/src/exception/usage/ArcanistRevisionStatusException.php
@@ -5,8 +5,10 @@
  */
 final class ArcanistRevisionStatusException extends ArcanistUsageException {
 
-  public function __construct() {
-    parent::__construct(pht('Rejected: You should never land revision without review. If you know what you are doing and still want to land, use `FORCE_LAND=__reasson__` in revisions summary.'));
+  public function __construct($read_more_url) {
+    parent::__construct(
+      pht("Rejected: You should never land revision without review. If you know what you are doing and still want to land, use `FORCE_LAND=__reasson__` in revisions summary. Read more: {$read_more_url}")
+    );
   }
 
 }

--- a/src/exception/usage/ArcanistRevisionStatusException.php
+++ b/src/exception/usage/ArcanistRevisionStatusException.php
@@ -7,7 +7,7 @@ final class ArcanistRevisionStatusException extends ArcanistUsageException {
 
   public function __construct($read_more_url) {
     parent::__construct(
-      pht("Rejected: You should never land revision without review. If you know what you are doing and still want to land, use `FORCE_LAND=__reasson__` in revisions summary. Read more: {$read_more_url}")
+      pht("Rejected: You should never land revision without review. If you know what you are doing and still want to land, use `FORCE_LAND=__reason__` in revisions summary. Read more: {$read_more_url}")
     );
   }
 

--- a/src/exception/usage/ArcanistRevisionStatusException.php
+++ b/src/exception/usage/ArcanistRevisionStatusException.php
@@ -5,9 +5,9 @@
  */
 final class ArcanistRevisionStatusException extends ArcanistUsageException {
 
-  public function __construct($read_more_url) {
+  public function __construct($message) {
     parent::__construct(
-      pht("Rejected: You should never land revision without review. If you know what you are doing and still want to land, use `FORCE_LAND=__reason__` in revisions summary. Read more: {$read_more_url}")
+      pht($message)
     );
   }
 

--- a/src/land/engine/ArcanistLandEngine.php
+++ b/src/land/engine/ArcanistLandEngine.php
@@ -454,9 +454,7 @@ abstract class ArcanistLandEngine
       }
 
       if(!$this->allowForcedLandWithoutReview($revision_refs)) {
-        $read_more_url = $this->getWorkflow()->getNotAcceptedReadMore();
-
-        throw new ArcanistRevisionStatusException($read_more_url);
+        throw new ArcanistRevisionStatusException($this->getWorkflow()->getNotAcceptedMessage());
       }
 
       $query = pht(

--- a/src/land/engine/ArcanistLandEngine.php
+++ b/src/land/engine/ArcanistLandEngine.php
@@ -454,7 +454,9 @@ abstract class ArcanistLandEngine
       }
 
       if(!$this->allowForcedLandWithoutReview($revision_refs)) {
-        throw new ArcanistRevisionStatusException();
+        $read_more_url = $this->getWorkflow()->getNotAcceptedReadMore();
+
+        throw new ArcanistRevisionStatusException($read_more_url);
       }
 
       $query = pht(

--- a/src/runtime/ArcanistRuntime.php
+++ b/src/runtime/ArcanistRuntime.php
@@ -122,8 +122,6 @@ final class ArcanistRuntime {
     $conduit_engine = $this->newConduitEngine($config, $args);
     $this->conduitEngine = $conduit_engine;
 
-    $docs_url = $config->getConfig('land.notaccepted.readmore');
-
     $phutil_workflows = array();
     foreach ($workflows as $key => $workflow) {
       $workflow
@@ -131,7 +129,8 @@ final class ArcanistRuntime {
         ->setConfigurationEngine($config_engine)
         ->setConfigurationSourceList($config)
         ->setConduitEngine($conduit_engine)
-        ->setNotAcceptedReadMore($docs_url);
+        ->setNotAcceptedMessage(
+          $config->getConfig('arc.land.notaccepted.message'));
 
       $phutil_workflows[$key] = $workflow->newPhutilWorkflow();
     }

--- a/src/runtime/ArcanistRuntime.php
+++ b/src/runtime/ArcanistRuntime.php
@@ -122,13 +122,16 @@ final class ArcanistRuntime {
     $conduit_engine = $this->newConduitEngine($config, $args);
     $this->conduitEngine = $conduit_engine;
 
+    $docs_url = $config->getConfig('land.notaccepted.readmore');
+
     $phutil_workflows = array();
     foreach ($workflows as $key => $workflow) {
       $workflow
         ->setRuntime($this)
         ->setConfigurationEngine($config_engine)
         ->setConfigurationSourceList($config)
-        ->setConduitEngine($conduit_engine);
+        ->setConduitEngine($conduit_engine)
+        ->setNotAcceptedReadMore($docs_url);
 
       $phutil_workflows[$key] = $workflow->newPhutilWorkflow();
     }

--- a/src/workflow/ArcanistWorkflow.php
+++ b/src/workflow/ArcanistWorkflow.php
@@ -76,8 +76,19 @@ abstract class ArcanistWorkflow extends Phobject {
   private $configurationSourceList;
 
   private $promptMap;
-  private $not_accepted_read_more_url;
+  // LOCAL MODIFICATION
+  private $not_accepted_message;
 
+  final public function setNotAcceptedMessage($message) {
+    $this->not_accepted_message = $message;
+    return $this;
+  }
+
+  final public function getNotAcceptedMessage() {
+    return $this->not_accepted_message;
+  }
+
+  // END LOCAL MODIFICATION
   final public function setToolset(ArcanistToolset $toolset) {
     $this->toolset = $toolset;
     return $this;
@@ -2463,16 +2474,6 @@ abstract class ArcanistWorkflow extends Phobject {
     }
 
     return $this;
-  }
-
-
-  final public function setNotAcceptedReadMore($read_more_url) {
-    $this->not_accepted_read_more_url = $read_more_url;
-    return $this;
-  }
-
-  final public function getNotAcceptedReadMore() {
-    return $this->not_accepted_read_more_url;
   }
 
 }

--- a/src/workflow/ArcanistWorkflow.php
+++ b/src/workflow/ArcanistWorkflow.php
@@ -76,6 +76,7 @@ abstract class ArcanistWorkflow extends Phobject {
   private $configurationSourceList;
 
   private $promptMap;
+  private $not_accepted_read_more_url;
 
   final public function setToolset(ArcanistToolset $toolset) {
     $this->toolset = $toolset;
@@ -2462,6 +2463,16 @@ abstract class ArcanistWorkflow extends Phobject {
     }
 
     return $this;
+  }
+
+
+  final public function setNotAcceptedReadMore($read_more_url) {
+    $this->not_accepted_read_more_url = $read_more_url;
+    return $this;
+  }
+
+  final public function getNotAcceptedReadMore() {
+    return $this->not_accepted_read_more_url;
   }
 
 }


### PR DESCRIPTION
In response for:
>One thing I think we'll want for wider audience is a link to learn more (a lot of engineers will wonder "what is this policy change, why do I have to do this") - rather than answer that question a dozen times, we should just put a link in the message it prints.
However the link will be to a RH-internal doc, so in the sense that we're building a reusable OSS for anyone on phabricator, it seems like we want to configure the message (probably in .arcconfig)

The link should be passed to `.arcconfig` as `land.notaccepted.readmore`