### PR TITLE
UX improvements for PHLQ flow, cleanup after landing & support stacks with arc land

### DIFF
--- a/src/config/arc/ArcanistArcConfigurationEngineExtension.php
+++ b/src/config/arc/ArcanistArcConfigurationEngineExtension.php
@@ -168,6 +168,16 @@ final class ArcanistArcConfigurationEngineExtension
         ->setSummary(
           pht(
             'Error message when attempting to land a non-accepted revision.')),
+      id(new ArcanistStringConfigOption())
+        ->setKey('arc.land.buildfailures.message')
+        ->setDefaultValue(
+          pht(
+            'Rejected: You should not land revisions with failed or ongoing builds. '.
+            'If you know what you are doing and still want to land, add a '.
+            '`ALLOW_FAILED_TESTS=<reason>` line to the revision summary and it will be audited.'))
+        ->setSummary(
+          pht(
+            'Error message when attempting to land a revision with failed builds.')),
       id(new ArcanistBoolConfigOption())
         ->setKey('phlq')
         ->setDefaultValue(false)
@@ -188,7 +198,7 @@ final class ArcanistArcConfigurationEngineExtension
           array(
             'phlq_uri',
           ))
-        ->setSummary(pht('PHLQ instance url.'))
+        ->setSummary(pht('PHLQ instance uri.'))
         ->setHelp(
           pht(
             'Associates this working copy with a specific installation of '.

--- a/src/land/engine/ArcanistLandEngine.php
+++ b/src/land/engine/ArcanistLandEngine.php
@@ -31,19 +31,6 @@ abstract class ArcanistLandEngine
   private $hasUnpushedChanges;
   private $pickArgument;
 
-  private $forceableBuildPlanPhids;
-  private $lintBuildPlanPhids;
-
-  final public function setForceableBuildPlanPhids($val) {
-    $this->forceableBuildPlanPhids = $val;
-    return $this;
-  }
-
-  final public function setLintBuildPlanPhids($val) {
-    $this->lintBuildPlanPhids = $val;
-    return $this;
-  }
-
   final public function setOntoRemote($onto_remote) {
     $this->ontoRemote = $onto_remote;
     return $this;
@@ -384,7 +371,11 @@ abstract class ArcanistLandEngine
     $not_accepted = array();
     foreach ($revision_refs as $revision_ref) {
       if (!$revision_ref->isStatusAccepted()) {
-        if (!$this->allowForcedLandWithoutReview(array($revision_ref))) {
+        if ($this->allowForcedLandWithoutReview(array($revision_ref))) {
+          $log->writeWarning(
+            pht('FORCE LANDING UNACCEPTED REVISION D%s', $revision_ref->getID()),
+            pht('Landing D%s in unaccepted state with FORCE_LAND', $revision_ref->getID()));
+        } else {
           $log->writeError(pht('REVIEW'), pht('Revision D%s not accepted', $revision_ref->getID()));
           throw new ArcanistRevisionStatusException($this->getWorkflow()->getNotAcceptedMessage());
         }
@@ -675,28 +666,32 @@ abstract class ArcanistLandEngine
       $plan_id = $plan_ref->getID();
       $plan_name = $plan_ref->getName();
 
+      $blocking_failed_builds = $this->getWorkflow()->getIsPhlq() || $this->getWorkflow()->getUsePhlq();
+      $lint_build_plan_phids = $this->getWorkflow()->getLintBuildPlanPhids();
+      $forceable_build_plan_phids = $this->getWorkflow()->getForceableBuildPlanPhids();
+
       if ($build_ref->isComplete()) {
         // If build plan is a lint plan then allow it to land in failed state
-        if ($this->lintBuildPlanPhids && in_array($plan_phid, $this->lintBuildPlanPhids)) {
+        if ($lint_build_plan_phids && in_array($plan_phid, $lint_build_plan_phids)) {
           $log->writeWarning(
             pht('LANDING D%s WITH FAILING LINT', $revision_ref->getID()),
-            pht('Linting failures on D%s not fatal for land (build plan %s: %s)', $revision_ref->getID(), $plan_id, $plan_name));
+            pht('Linting failures on D%s not fatal for land with ALLOW_FAILED_TESTS (build plan %s: %s)', $revision_ref->getID(), $plan_id, $plan_name));
           continue;
         }
 
         // If build plan is an forceable plan then allow it to land in failed state if
         // ALLOW_FAILED_TESTS is set
-        if ($this->forceableBuildPlanPhids && $allow_failing_forceable_tests && in_array($plan_phid, $this->forceableBuildPlanPhids)) {
+        if ($forceable_build_plan_phids && $allow_failing_forceable_tests && in_array($plan_phid, $forceable_build_plan_phids)) {
           $log->writeWarning(
             pht('FORCE LANDING D%s WITH FAILED TESTS', $revision_ref->getID()),
-            pht('Landing D%s with failing forceable tests (build plan %s: %s)', $revision_ref->getID(), $plan_id, $plan_name));
+            pht('Landing D%s with failing forceable tests with ALLOW_FAILED_TESTS  (build plan %s: %s)', $revision_ref->getID(), $plan_id, $plan_name));
           continue;
         }
 
         $has_failures = true;
       } else {
         // If build plan is a lint plan then allow it to land in ongoing state
-        if ($this->lintBuildPlanPhids && in_array($plan_phid, $this->lintBuildPlanPhids)) {
+        if ($lint_build_plan_phids && in_array($plan_phid, $lint_build_plan_phids)) {
           $log->writeWarning(
             pht('LANDING D%s WITH ONGOING LINT', $revision_ref->getID()),
             pht('Linting ongoing on D%s not fatal for land (build plan %s: %s)', $revision_ref->getID(), $plan_id, $plan_name));
@@ -705,7 +700,7 @@ abstract class ArcanistLandEngine
 
         // If build plan is an forceable plan then allow it to land in ongoing state if
         // ALLOW_FAILED_TESTS is set
-        if ($this->forceableBuildPlanPhids && $allow_failing_forceable_tests && in_array($plan_phid, $this->forceableBuildPlanPhids)) {
+        if ($forceable_build_plan_phids && $allow_failing_forceable_tests && in_array($plan_phid, $forceable_build_plan_phids)) {
           $log->writeWarning(
             pht('FORCE LANDING D%s WITH ONGOING TESTS', $revision_ref->getID()),
             pht('Landing D%s with ongoing forceable tests (build plan %s: %s)', $revision_ref->getID(), $plan_id, $plan_name));
@@ -713,6 +708,11 @@ abstract class ArcanistLandEngine
         }
 
         $has_ongoing = true;
+      }
+
+      if ($blocking_failed_builds) {
+        $log->writeError(pht('BUILD'), pht('Revision D%s has build failures or ongoing builds', $revision_ref->getID()));
+        throw new ArcanistRevisionStatusException($this->getWorkflow()->getBuildFailuresMessage());
       }
 
       $problem_builds[] = $build_ref;

--- a/src/land/engine/ArcanistPhlqLandEngine.php
+++ b/src/land/engine/ArcanistPhlqLandEngine.php
@@ -176,7 +176,7 @@ class ArcanistPhlqLandEngine extends ArcanistGitLandEngine {
     $land_rev_id = end($revision_ids);
     $remote_url = $api->getRemoteUrl();
     $this->landRevision($land_rev_id, $remote_url);
-    $message = "Land request send. Landing logs: ".$this->phlqUrl . $this->phlqLogsPath . $land_rev_id;
+    $message = "Land request sent. Landing logs: ".$this->phlqUrl . $this->phlqLogsPath . $land_rev_id;
     $log->writeSuccess(
       pht('DONE'),
       pht($message));

--- a/src/repository/api/ArcanistGitAPI.php
+++ b/src/repository/api/ArcanistGitAPI.php
@@ -1824,8 +1824,4 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
     list($stdout) = $this->execxLocal('config --get remote.origin.url');
     return rtrim($stdout, "\n");
   }
-
-  public function cleanTags() {
-    $this->execxLocal('fetch origin --prune --tags');
-  }
 }

--- a/src/runtime/ArcanistRuntime.php
+++ b/src/runtime/ArcanistRuntime.php
@@ -131,9 +131,11 @@ final class ArcanistRuntime {
         ->setConduitEngine($conduit_engine)
         ->setNotAcceptedMessage(
           $config->getConfig('arc.land.notaccepted.message'))
+        ->setBuildFailuresMessage(
+          $config->getConfig('arc.land.buildfailures.message'))
         ->setUsePhlq($config->getConfig('phlq'))
         ->setIsPhlq($config->getConfig('is.phlq'))
-        ->setPhlqUrl($config->getConfig('phlq.uri'))
+        ->setPhlqUri($config->getConfig('phlq.uri'))
         ->setForceableBuildPlanPhids($config->getConfig('forceable.build.plan.phids'))
         ->setLintBuildPlanPhids($config->getConfig('lint.build.plan.phids'));
 

--- a/src/workflow/ArcanistLandWorkflow.php
+++ b/src/workflow/ArcanistLandWorkflow.php
@@ -296,16 +296,23 @@ EOTEXT
     $working_copy = $this->getWorkingCopy();
     $repository_api = $working_copy->getRepositoryAPI();
 
+    $log = $this->getLogEngine();
+    $phlq_uri = $this->getPhlqUri();
+    $use_phlq = $this->getUsePhlq();
+
+    if ($use_phlq && empty($phlq_uri)) {
+      $log->writeWarning(
+        pht('PHLQ'),
+        pht("You have PHLQ enabled, but phlq.uri is not configured. Attempting at landing by git push."));
+      $use_phlq = false;
+    }
+
     if ($this->getIsPhlq()) {
-      // If landing in PHLQ service we use the standard land engine and set lint build plan PHIDS
-      // that are allowed to land in failed state and we set forceable build plan PHIDS that are
-      // allowed to land in failed state if ALLOW_FAILED_TESTS is set
+      // If landing in PHLQ service we use the standard land engine
       $land_engine = $repository_api->getLandEngine();
-      $land_engine->setLintBuildPlanPhids($this->getLintBuildPlanPhids());
-      $land_engine->setForceableBuildPlanPhids($this->getForceableBuildPlanPhids());
-    } else if ($this->getUsePhlq()) {
-      $land_engine = new ArcanistPhlqLandEngine($this->getPhlqUrl());
-      $land_engine->setRepositoryAPI($repository_api);  
+    } else if ($use_phlq) {
+      $land_engine = new ArcanistPhlqLandEngine($this->getPhlqUri());
+      $land_engine->setRepositoryAPI($repository_api);
     } else {
       $land_engine = $repository_api->getLandEngine();
     }

--- a/src/workflow/ArcanistWorkflow.php
+++ b/src/workflow/ArcanistWorkflow.php
@@ -79,9 +79,10 @@ abstract class ArcanistWorkflow extends Phobject {
 
   // LOCAL MODIFICATION
   private $not_accepted_message;
+  private $build_failures_message;
   private $use_phlq;
   private $is_phlq;
-  private $phlq_url;
+  private $phlq_uri;
   private $forceable_build_plan_phids;
   private $lint_build_plan_phids;
 
@@ -94,13 +95,22 @@ abstract class ArcanistWorkflow extends Phobject {
     return $this->not_accepted_message;
   }
 
-  final public function setPhlqUrl($url) {
-    $this->phlq_url = $url;
+  final public function setBuildFailuresMessage($message) {
+    $this->build_failures_message = $message;
     return $this;
   }
 
-  final public function getPhlqUrl() {
-    return $this->phlq_url;
+  final public function getBuildFailuresMessage() {
+    return $this->build_failures_message;
+  }
+
+  final public function setPhlqUri($url) {
+    $this->phlq_uri = $url;
+    return $this;
+  }
+
+  final public function getPhlqUri() {
+    return $this->phlq_uri;
   }
 
   final public function setUsePhlq(bool $val) {


### PR DESCRIPTION
`arc land <commit>` is now supported to land a single commit in a stack

both `arc` and `sw` now use the `/land/stack` PHLQ endpoint so the old `/land/<revision>` endpoint can be removed once all users are on the latest arc.

CLEANUP steps consider if there are local changes in which case it is halted.

If branch is not master the merge-base is checked to see if the branch is fully merged (which it may not be if landed only part of a stack). Only if the branch is fully merged will arc switch to master and delete the local branch.