### PR TITLE
add non-blocking.build.plan.phids option

### DIFF
--- a/src/config/arc/ArcanistArcConfigurationEngineExtension.php
+++ b/src/config/arc/ArcanistArcConfigurationEngineExtension.php
@@ -223,6 +223,21 @@ final class ArcanistArcConfigurationEngineExtension
             ["PHID-ABCD-abcdefghijklmnopqrst"],
           )),
       id(new ArcanistStringListConfigOption())
+        ->setKey('non-blocking.build.plan.phids')
+        ->setDefaultValue(array())
+        ->setAliases(
+          array(
+            'non_blocking_build_plan_phids',
+          ))
+        ->setSummary(
+          pht(
+            'List PHIDs of build plans which can be landed with failing '.
+            'status.'))
+        ->setExamples(
+          array(
+            ["PHID-ABCD-abcdefghijklmnopqrst"],
+          )),
+      id(new ArcanistStringListConfigOption())
         ->setKey('lint.build.plan.phids')
         ->setDefaultValue(array())
         ->setAliases(

--- a/src/runtime/ArcanistRuntime.php
+++ b/src/runtime/ArcanistRuntime.php
@@ -137,6 +137,7 @@ final class ArcanistRuntime {
         ->setIsPhlq($config->getConfig('is.phlq'))
         ->setPhlqUri($config->getConfig('phlq.uri'))
         ->setForceableBuildPlanPhids($config->getConfig('forceable.build.plan.phids'))
+        ->setNonBlockingBuildPlanPhids($config->getConfig('non-blocking.build.plan.phids'))
         ->setLintBuildPlanPhids($config->getConfig('lint.build.plan.phids'));
 
       $phutil_workflows[$key] = $workflow->newPhutilWorkflow();

--- a/src/workflow/ArcanistWorkflow.php
+++ b/src/workflow/ArcanistWorkflow.php
@@ -84,6 +84,7 @@ abstract class ArcanistWorkflow extends Phobject {
   private $is_phlq;
   private $phlq_uri;
   private $forceable_build_plan_phids;
+  private $non_blocking_build_plan_phids;
   private $lint_build_plan_phids;
 
   final public function setNotAcceptedMessage($message) {
@@ -138,6 +139,15 @@ abstract class ArcanistWorkflow extends Phobject {
 
   final public function getForceableBuildPlanPhids() {
     return $this->forceable_build_plan_phids;
+  }
+
+  final public function setNonBlockingBuildPlanPhids($val) {
+    $this->non_blocking_build_plan_phids = $val;
+    return $this;
+  }
+
+  final public function getNonBlockingBuildPlanPhids() {
+    return $this->non_blocking_build_plan_phids;
   }
 
   final public function setLintBuildPlanPhids($val) {


### PR DESCRIPTION
improves warning & error messages when running `arc land`.

`lint.build.plan.phids` could in theory be renamed to `non-blocking.build.plan.phids` but that would break backward compatibility so the distinction between the two is kept.

manual testing on this:

```
gregmagolan--C02CF8B1MD6R:rh gregmagolan$ darc land
 STRATEGY  Merging with "squash" strategy, the default strategy.
 SOURCE  Landing the current branch, "arcpatch-D198668".
 ONTO REMOTE  Landing onto remote "origin", the default remote under Git.
 ONTO TARGET  Landing onto target "master", the default target under Git.
 INTO REMOTE  Will merge into remote "origin" by default, because this is the remote the change is landing onto.
 INTO TARGET  Will merge into target "master" by default, because this is the "onto" target.
 FETCH  Fetching "master" from remote "origin"...

  $   git fetch --no-tags --quiet -- origin master


 INTO COMMIT  Preparing merge into "master" from remote "origin", at commit "83ee217ece6e".
 LANDING  These changes will land:

  *   D198668 [arc] add all Jenkins build plans to non-blockable build plans
        6ef6bce0d800  [arc] add all Jenkins build plans to non-blockable build plans

 >>>  Land these changes? [y/N/?] y

 <!> 1 REVISION(S) ARE NOT ACCEPTED 
You are landing 1 revision(s) which are not in state "Accepted", indicating
that they have not been accepted by reviewers. Normally, you should land
changes only once they have been accepted. These revisions are in the wrong
state:

  *   D198668 [arc] add all Jenkins build plans to non-blockable build plans
        Status: Needs Review
 FORCE LANDING UNACCEPTED REVISION D198668  Landing D198668 in unaccepted state with FORCE_LAND

 >>>  Land 1 revision(s) in the wrong state? [y/N/?] y
 BLOCKING ONGOING TESTS  Blocking ongoing build plan on D198668 are fatal for land (build plan 61: Buildkite (new CI, pls keep it green, ask in #ci))
 NON-BLOCKING ONGOING TESTS  Non-blocking ongoing tests on D198668 not fatal for land (build plan 48: tests (apollo))
 NON-BLOCKING ONGOING TESTS  Non-blocking ongoing tests on D198668 not fatal for land (build plan 47: tests)
 <!> ONGOING BUILDS 
1 revision(s) have ongoing builds:

  *   D198668 [arc] add all Jenkins build plans to non-blockable build plans
  *     B470256 Buildable "B470256"
 ://      https://phabricator.robinhood.com/B470256
  *       Build 1136441 Buildkite (new CI, pls keep it green, ask in #ci)
  *       Build 1136440 tests (apollo)
  *       Build 1136439 tests

 BUILD  Revision D198668 has blocking build failures or ongoing builds
 ---  To keep master green, it is recommended that blocking CI builds pass before landing. Read more: http://go/landqueue#failing-tests
```

&&


```
gregmagolan--C02CF8B1MD6R:rh gregmagolan$ darc land
 STRATEGY  Merging with "squash" strategy, the default strategy.
 SOURCE  Landing the current branch, "arcpatch-D198668".
 ONTO REMOTE  Landing onto remote "origin", the default remote under Git.
 ONTO TARGET  Landing onto target "master", the default target under Git.
 INTO REMOTE  Will merge into remote "origin" by default, because this is the remote the change is landing onto.
 INTO TARGET  Will merge into target "master" by default, because this is the "onto" target.
 FETCH  Fetching "master" from remote "origin"...

  $   git fetch --no-tags --quiet -- origin master


 INTO COMMIT  Preparing merge into "master" from remote "origin", at commit "83ee217ece6e".
 LANDING  These changes will land:

  *   D198668 [arc] add all Jenkins build plans to non-blockable build plans
        6ef6bce0d800  [arc] add all Jenkins build plans to non-blockable build plans

 >>>  Land these changes? [y/N/?] y

 <!> 1 REVISION(S) ARE NOT ACCEPTED 
You are landing 1 revision(s) which are not in state "Accepted", indicating
that they have not been accepted by reviewers. Normally, you should land
changes only once they have been accepted. These revisions are in the wrong
state:

  *   D198668 [arc] add all Jenkins build plans to non-blockable build plans
        Status: Needs Review
 FORCE LANDING UNACCEPTED REVISION D198668  Landing D198668 in unaccepted state with FORCE_LAND

 >>>  Land 1 revision(s) in the wrong state? [y/N/?] y
 BLOCKING FAILED TESTS  Blocking build plan failures on D198668 are fatal for land (build plan 61: Buildkite (new CI, pls keep it green, ask in #ci))
 NON-BLOCKING FAILED TESTS  Non-blocking build plan failures on D198668 not fatal for land (build plan 48: tests (apollo))
 NON-BLOCKING FAILED TESTS  Non-blocking build plan failures on D198668 not fatal for land (build plan 47: tests)
 <!> BUILD FAILURES 
1 revision(s) have build failures:

  *   D198668 [arc] add all Jenkins build plans to non-blockable build plans
  *     B470256 Buildable "B470256"
 ://      https://phabricator.robinhood.com/B470256
  *       Build 1136441 Buildkite (new CI, pls keep it green, ask in #ci)
  *       Build 1136440 tests (apollo)
  *       Build 1136439 tests

 BUILD  Revision D198668 has blocking build failures or ongoing builds
 ---  To keep master green, it is recommended that blocking CI builds pass before landing. Read more: http://go/landqueue#failing-tests
```

&&

```
gregmagolan--C02CF8B1MD6R:rh gregmagolan$ darc land
 STRATEGY  Merging with "squash" strategy, the default strategy.
 SOURCE  Landing the current branch, "arcpatch-D198668".
 ONTO REMOTE  Landing onto remote "origin", the default remote under Git.
 ONTO TARGET  Landing onto target "master", the default target under Git.
 INTO REMOTE  Will merge into remote "origin" by default, because this is the remote the change is landing onto.
 INTO TARGET  Will merge into target "master" by default, because this is the "onto" target.
 FETCH  Fetching "master" from remote "origin"...

  $   git fetch --no-tags --quiet -- origin master


 INTO COMMIT  Preparing merge into "master" from remote "origin", at commit "73439001e454".
 LANDING  These changes will land:

  *   D198668 [arc] add all Jenkins build plans to non-blockable build plans
        7944c4039262  [arc] add all Jenkins build plans to non-blockable build plans

 >>>  Land these changes? [y/N/?] y

 <!> 1 REVISION(S) ARE NOT ACCEPTED 
You are landing 1 revision(s) which are not in state "Accepted", indicating
that they have not been accepted by reviewers. Normally, you should land
changes only once they have been accepted. These revisions are in the wrong
state:

  *   D198668 [arc] add all Jenkins build plans to non-blockable build plans
        Status: Needs Review
 FORCE LANDING UNACCEPTED REVISION D198668  Landing D198668 in unaccepted state with FORCE_LAND

 >>>  Land 1 revision(s) in the wrong state? [y/N/?] y
 NON-BLOCKING FAILED TESTS  Non-blocking build plan failures on D198668 not fatal for land (build plan 48: tests (apollo))
 NON-BLOCKING FAILED TESTS  Non-blocking build plan failures on D198668 not fatal for land (build plan 47: tests)
 <!> BUILD FAILURES 
1 revision(s) have build failures:

  *   D198668 [arc] add all Jenkins build plans to non-blockable build plans
  *     B470268 Buildable "B470268"
 ://      https://phabricator.robinhood.com/B470268
  *       Build 1136496 tests (apollo)
  *       Build 1136495 tests


 >>>  Land 1 revision(s) anyway, despite failed builds? [y/N/?] y
 MERGING  7944c4039262 [arc] add all Jenkins build plans to non-blockable build plans
```