### PR TITLE
Handle local changes when landing with land queue & more permissive regex for FORCE_LAND & ALLOW_FAILED_TESTS

### DIFF
--- a/src/land/engine/ArcanistLandEngine.php
+++ b/src/land/engine/ArcanistLandEngine.php
@@ -276,7 +276,7 @@ abstract class ArcanistLandEngine
   }
 
   final public function allowForcedLandWithoutReview($revision_refs) {
-    $expected_pattern = "/^FORCE_LAND=.+/m";
+    $expected_pattern = "/\sFORCE_LAND=.+/m";
     $this->getWorkflow()->loadHardpoints(
       $revision_refs,
       array(
@@ -292,7 +292,7 @@ abstract class ArcanistLandEngine
   }
 
   final public function allowForcedLandWithFailingForceableTests($revision_refs) {
-    $expected_pattern = "/^ALLOW_FAILED_TESTS=.+/m";
+    $expected_pattern = "/\sALLOW_FAILED_TESTS=.+/m";
     $this->getWorkflow()->loadHardpoints(
       $revision_refs,
       array(
@@ -879,7 +879,7 @@ abstract class ArcanistLandEngine
       ->execute();
   }
 
-  final protected function confirmImplicitCommits(array $sets, array $symbols) {
+  protected function confirmImplicitCommits(array $sets, array $symbols) {
     assert_instances_of($sets, 'ArcanistLandCommitSet');
     assert_instances_of($symbols, 'ArcanistLandSymbol');
 

--- a/src/workflow/ArcanistLandWorkflow.php
+++ b/src/workflow/ArcanistLandWorkflow.php
@@ -241,6 +241,10 @@ EOTEXT
           pht(
             'Confirms landing more than %s commit(s) in a single operation.',
             new PhutilNumber($this->getLargeWorkingSetLimit()))),
+      $this->newPrompt('arc.land.confirm-timestamps')
+        ->setDescription(
+          pht(
+            'Confirms that to land when commit timestamps are ahead of latest diff')),
       $this->newPrompt('arc.land.confirm')
         ->setDescription(
           pht(


### PR DESCRIPTION
* Fail on implicit commits when landing with land queue. These are local change that have not yet been diffed.
* Warn if local commit timestamp is ahead of latest revision diff to confirm land.
* More permissive regex for FORCE_LAND & ALLOW_FAILED_TESTS to allow inline such as "Summary: ALLOW_FAILED_TESTS=<reason>"
* No longer send repo_url as part of land request to land queue. This is no longer needed as land queue can deduce the repo_url from the revision.

Failure on implicit commit
```
$ darc land
 STRATEGY  Merging with "squash" strategy, the default strategy.
 SOURCE  Landing the current branch, "arcpatch-D200280".
 ONTO REMOTE  Landing onto remote "origin", the default remote under Git.
 ONTO TARGET  Landing onto target "master", the default target under Git.
 INTO REMOTE  Will merge into remote "origin" by default, because this is the remote the change is landing onto.
 INTO TARGET  Will merge into target "master" by default, because this is the "onto" target.
 FETCH  Fetching "master" from remote "origin"...

  $   git fetch --no-tags --quiet -- origin master


 INTO COMMIT  Preparing merge into "master" from remote "origin", at commit "52187ad648cc".
 IMPLICIT COMMITS  Some commits reachable from the specified sources ("arcpatch-D200280") are not associated with revisions and may not have been reviewed. 
 ---  All commits must be associated with revisions to land with land queue. Land queue is NOT aware of local changes that have not been pushed to the revision and will land the latest diff in the revision. Run 'arc diff' before landing.
```

Warning on timestamp ahead of latest diff:
```
$ darc land
 STRATEGY  Merging with "squash" strategy, the default strategy.
 SOURCE  Landing the current branch, "arcpatch-D200280".
 ONTO REMOTE  Landing onto remote "origin", the default remote under Git.
 ONTO TARGET  Landing onto target "master", the default target under Git.
 INTO REMOTE  Will merge into remote "origin" by default, because this is the remote the change is landing onto.
 INTO TARGET  Will merge into target "master" by default, because this is the "onto" target.
 FETCH  Fetching "master" from remote "origin"...

  $   git fetch --no-tags --quiet -- origin master


 INTO COMMIT  Preparing merge into "master" from remote "origin", at commit "52187ad648cc".

 <!> POTENTIAL UNPUSHED LOCAL CHANGES FOR D200280 
Local commit cd46df7956a7ab1cd4e4dbe95af998db06acec0a (fum) in revision
D200280 has a timestamp that is 00h 00m 45s ahead of the revision's latest
diff timestamp.

Land queue is NOT aware of local changes that have not been pushed to the
revision and will land the latest diff in revision D200280.

If you have rebased to resolve merge conflicts or made other local changes
that have not been pushed to the revision, you must call 'arc diff' again
before landing.

If you are landing after an 'arc patch' and have not made any local changes
then you may ignore this warning. Local timestamps are expected to be newer
after patching.



 >>>  Ignore potential local changes for D200280? [y/N/?] 

```