### PR TITLE
Don't use phlq if onto argument is given

### DIFF
--- a/src/workflow/ArcanistLandWorkflow.php
+++ b/src/workflow/ArcanistLandWorkflow.php
@@ -311,6 +311,13 @@ EOTEXT
       $use_phlq = false;
     }
 
+    if($use_phlq && !empty($this->getArgument('onto'))) {
+      $log->writeWarning(
+        pht('PHLQ'),
+        pht("You have PHLQ enabled, but have specified an -onto argument. Attempting at landing by git push."));
+      $use_phlq = false;
+    }
+
     if ($this->getIsPhlq()) {
       // If landing in PHLQ service we use the standard land engine
       $land_engine = $repository_api->getLandEngine();


### PR DESCRIPTION
Because phlq does not itself support the onto argument, this is a
simple ergonomics improvement for users attempting to land with onto.

Without this change, phlq proceeds to ignore `onto` and merges to the
default branch in its configuration.