### PR TITLE
check for at least one reviewer before FORCE_LAND works

### DIFF
--- a/src/config/arc/ArcanistArcConfigurationEngineExtension.php
+++ b/src/config/arc/ArcanistArcConfigurationEngineExtension.php
@@ -164,7 +164,7 @@ final class ArcanistArcConfigurationEngineExtension
           pht(
             'Rejected: You should never land revision without review. '.
             'If you know what you are doing and still want to land, add a '.
-            '`FORCE_LAND=<reason>` line to the revision summary and it will be audited.'))
+            '`ALLOW_UNACCEPTED=<reason>` line to the revision summary and it will be audited.'))
         ->setSummary(
           pht(
             'Error message when attempting to land a non-accepted revision.')),

--- a/src/land/engine/ArcanistLandEngine.php
+++ b/src/land/engine/ArcanistLandEngine.php
@@ -293,7 +293,7 @@ abstract class ArcanistLandEngine
   }
 
   final public function allowForcedLandWithoutReviewState($revision_refs) {
-    $expected_pattern = "/\sFORCE_LAND=.+/m";
+    $expected_pattern = "/\sALLOW_UNACCEPTED=.+/m";
     $this->getWorkflow()->loadHardpoints(
       $revision_refs,
       array(
@@ -499,7 +499,7 @@ abstract class ArcanistLandEngine
         }
         $log->writeWarning(
           pht('FORCE LANDING UNACCEPTED REVISION D%s', $revision_ref->getID()),
-          pht('Landing D%s in unaccepted state with FORCE_LAND', $revision_ref->getID()));
+          pht('Landing D%s in unaccepted state with ALLOW_UNACCEPTED', $revision_ref->getID()));
       }
 
       $query = pht(


### PR DESCRIPTION
Tested with https://phabricator.robinhood.com/D271444

```
~/robinhood/rh test-force-land $ ~/robinhood/arcanist/bin/arc land --onto master
 PHLQ  You have PHLQ enabled, but have specified an -onto argument. Attempting at landing by git push.
 STRATEGY  Merging with "squash" strategy, the default strategy.
 SOURCE  Landing the current branch, "test-force-land".
 ONTO REMOTE  Remote "origin" was selected by following tracking branches upstream to the closest remote.
 ONTO TARGET  Refs were selected with the "--onto" flag: master.
 INTO REMOTE  Will merge into remote "origin" by default, because this is the remote the change is landing onto.
 INTO TARGET  Will merge into target "master" by default, because this is the "onto" target.
 FETCH  Fetching "master" from remote "origin"...

  $   git fetch --no-tags --quiet -- origin master


 INTO COMMIT  Preparing merge into "master" from remote "origin", at commit "b0118254aeda".
 LANDING  These changes will land:

  *   D271444 a test commit to make sure I can't force land without a reviewer
        a1f845a296d6  a test commit to make sure I can't force land without a reviewer

 >>>  Land these changes? <y>
 >>>  (Using saved response to prompt "arc.land.confirm".)


 <!> 1 REVISION(S) ARE NOT ACCEPTED
You are landing 1 revision(s) which are not in state "Accepted", indicating
that they have not been accepted by reviewers. Normally, you should land
changes only once they have been accepted. These revisions are in the wrong
state:

  *   D271444 a test commit to make sure I can't force land without a reviewer
        Status: Draft
 REVIEW  Revision D271444 not accepted by at least one person
 ---  Robinhood policy requires that revisions be accepted before landing. Read more: https://robinhood.atlassian.net/wiki/spaces/EN/pages/998703113/Unreviewed+Commits
```