### PR TITLE
use the commit message string directly

### DIFF
--- a/src/land/engine/ArcanistLandEngine.php
+++ b/src/land/engine/ArcanistLandEngine.php
@@ -276,6 +276,7 @@ abstract class ArcanistLandEngine
   }
 
   final public function allowForcedLandInMessage($revision_refs) {
+    $expected_pattern = "/^Reviewed By: .+$/m";
     $this->getWorkflow()->loadHardpoints(
       $revision_refs,
       array(
@@ -283,9 +284,8 @@ abstract class ArcanistLandEngine
       ));
     foreach($revision_refs as $ref){
       $commit_msg = $ref->getCommitMessage();
-      $commit = ArcanistDifferentialCommitMessage::newFromRawCorpus($commit_msg);
       # Even if you are forcing the land, you need to have 1 reviewer
-      if ($commit->getFieldValue('reviewerPHIDs') > 0) {
+      if (preg_match($expected_pattern, $commit_msg) > 0){
         return true;
       }
     }


### PR DESCRIPTION
So it turns out that `ArcanistDifferentialCommitMessage::newFromRawCorpus` doesn't fill out the `fields` and you have to call conduit for that. I went down that rabbit hole but it involves changing the land workflow to have a conduit instantiated and that felt pretty intrusive. 

It turns out Evan is smart and if you try to put `Reviewed By:` in your test plan or summary it says:

```
The value you have entered in "Test Plan" can not be parsed unambiguously when rendered in a commit message. Edit the message so that keywords like "Summary:" and "Test Plan:" do not appear at the beginning of lines. Parsed keys: reviewedByPHIDs.
```

So we can just rely on the commit message format to know if it was reviewed